### PR TITLE
accentColor -> colorScheme.secondary

### DIFF
--- a/lib/Picker.dart
+++ b/lib/Picker.dart
@@ -439,7 +439,7 @@ class PickerWidgetState<T> extends State<_PickerWidget> {
             textScaleFactor: MediaQuery.of(context).textScaleFactor,
             style: style ??
                 theme!.textTheme.button!.copyWith(
-                    color: theme!.accentColor,
+                    color: theme!.colorScheme.secondary,
                     fontSize: Picker.DefaultTextSize)));
   }
 
@@ -452,7 +452,7 @@ class PickerWidgetState<T> extends State<_PickerWidget> {
       items.add(DefaultTextStyle(
           style: picker.cancelTextStyle ??
               theme!.textTheme.button!.copyWith(
-                  color: theme!.accentColor, fontSize: Picker.DefaultTextSize),
+                  color: theme!.colorScheme.secondary, fontSize: Picker.DefaultTextSize),
           child: picker.cancel!));
     } else {
       String? _cancelText =
@@ -480,7 +480,7 @@ class PickerWidgetState<T> extends State<_PickerWidget> {
       items.add(DefaultTextStyle(
           style: picker.confirmTextStyle ??
               theme!.textTheme.button!.copyWith(
-                  color: theme!.accentColor, fontSize: Picker.DefaultTextSize),
+                  color: theme!.colorScheme.secondary, fontSize: Picker.DefaultTextSize),
           child: picker.confirm!));
     } else {
       String? _confirmText =


### PR DESCRIPTION
accentColor が非推奨になっていたため colorScheme.secondary に置き換えました。

雑に警告内容貼っておきます。
```
'accentColor' is deprecated and shouldn't be used. Use colorScheme.secondary instead. 
For more information, consult the migration guide at https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. 
This feature was deprecated after v2.3.0-0.1.pre. (Documentation)  Try replacing the use of the deprecated member with the replacement.
```